### PR TITLE
Fix a url-relevant BUG

### DIFF
--- a/view/mdui/layout.php
+++ b/view/mdui/layout.php
@@ -69,7 +69,7 @@
 			<a href="/" class="mdui-typo-headline"><?php e(config('site_name'));?></a>
 			<?php foreach((array)$navs as $n=>$l):?>
 			<i class="mdui-icon material-icons mdui-icon-dark" style="margin:0;">chevron_right</i>
-			<a href="<?php e($l);?>"><?php e($n);?></a>
+			<a href="<?php e(str_replace('%2F','/',str_replace('%2F%3F%2F','/?/',rawurlencode($l))));?>"><?php e($n);?></a>
 			<?php endforeach;?>
 			<!--<a href="javascript:;" class="mdui-btn mdui-btn-icon"><i class="mdui-icon material-icons">refresh</i></a>-->
 		</div>

--- a/view/nexmoe/layout.php
+++ b/view/nexmoe/layout.php
@@ -18,7 +18,7 @@
 			<a href="/"><?php e(config('site_name'));?></a>
 			<?php foreach((array)$navs as $n=>$l):?>
 			<i class="mdui-icon material-icons mdui-icon-dark" style="margin:0;">chevron_right</i>
-			<a href="<?php e($l);?>"><?php e($n);?></a>
+			<a href="<?php e(str_replace('%2F','/',str_replace('%2F%3F%2F','/?/',rawurlencode($l))));?>"><?php e($n);?></a>
 			<?php endforeach;?>
 			<!--<a href="javascript:;" class="mdui-btn mdui-btn-icon"><i class="mdui-icon material-icons">refresh</i></a>-->
 		</div>


### PR DESCRIPTION
我自己也在维护一个[OneIndex的衍生项目](https://github.com/xqymain/OneIndexR)，在早些时候发现了这个问题。

影响范围包括nexmoe和material，可在下方复现：


修复前：https://data.srv.pub/?/Music&Video/ （会请求Music目录）
修复后：https://data.srv.pub/?/Music%26Video/  （正常请求Music&Video）